### PR TITLE
Remove kws: does not exist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,4 @@ setup(
     requires = [
         'Django (>=1.4)',
     ],
-    **kws
 )


### PR DESCRIPTION
4bd0e9fc removed the `kws` definition from `setup.py` but did not stop using it.
