### PR TITLE
ugettext -> gettext

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -16,4 +16,4 @@ Contributions by
     * Mikhail Korobov <http://github.com/kmike>
     * Henrik Heimbuerger <http://github.com/hheimbuerger>
     * Alexander Ovchinnikov <alexander@entropia.us>
-
+    * Craig Anderson <http://craiga.id.au/>

--- a/flatblocks/models.py
+++ b/flatblocks/models.py
@@ -1,6 +1,6 @@
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class FlatBlock(models.Model):

--- a/flatblocks/views.py
+++ b/flatblocks/views.py
@@ -1,6 +1,6 @@
 from django.http import HttpResponse, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from flatblocks.forms import FlatBlockForm
 from flatblocks.models import FlatBlock
 


### PR DESCRIPTION
`ugettext` has been an alias for `gettext` since Django 2.0.

As this package requires Django >= 2.2, this shouldn't be a problem.

Resolves https://github.com/jazzband/django-flatblocks/issues/27