### PR TITLE
Revert "Use setuptools_scm."

### DIFF
--- a/flatblocks/__init__.py
+++ b/flatblocks/__init__.py
@@ -1,7 +1,0 @@
-from pkg_resources import get_distribution, DistributionNotFound
-
-try:
-    __version__ = get_distribution("django-flatblocks").version
-except DistributionNotFound:
-    # package is not installed
-    __version__ = None

--- a/setup.py
+++ b/setup.py
@@ -1,52 +1,51 @@
 import io
+
 from setuptools import setup, find_packages
 
 
 setup(
-    name="django-flatblocks",
-    use_scm_version={"version_scheme": "post-release"},
-    setup_requires=["setuptools_scm"],
-    description="django-flatblocks acts like django.contrib.flatpages but "
-    "for parts of a page; like an editable help box you want "
-    "show alongside the main content.",
-    long_description=io.open("README.rst", encoding="utf-8").read(),
-    keywords="django apps",
-    license="New BSD License",
-    author="Horst Gutmann, Curtis Maloney",
-    author_email="curtis@tinbrain.net",
-    url="https://github.com/jazzband/django-flatblocks/",
+    name='django-flatblocks',
+    version='0.9.4',
+    description='django-flatblocks acts like django.contrib.flatpages but '
+                'for parts of a page; like an editable help box you want '
+                'show alongside the main content.',
+    long_description=io.open('README.rst', encoding='utf-8').read(),
+    keywords='django apps',
+    license='New BSD License',
+    author='Horst Gutmann, Curtis Maloney',
+    author_email='curtis@tinbrain.net',
+    url='http://github.com/funkybob/django-flatblocks/',
     classifiers=[
-        "Development Status :: 4 - Beta",
-        "Environment :: Plugins",
-        "Environment :: Web Environment",
-        "Framework :: Django",
-        "Framework :: Django :: 2.2",
-        "Framework :: Django :: 3.0",
-        "Framework :: Django :: 3.1",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: BSD License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: Implementation :: PyPy",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "Topic :: Internet :: WWW/HTTP",
-        "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
+        'Development Status :: 4 - Beta',
+        'Environment :: Plugins',
+        'Environment :: Web Environment',
+        'Framework :: Django',
+        'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.0',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: BSD License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: Implementation :: PyPy',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        'Topic :: Internet :: WWW/HTTP',
+        'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
-    packages=find_packages(exclude=["tests"]),
+    packages=find_packages(exclude=['tests']),
     package_data={
-        "flatblocks": [
-            "templates/flatblocks/*.html",
-            "locale/*/*/*.mo",
-            "locale/*/*/*.po",
+        'flatblocks': [
+            'templates/flatblocks/*.html',
+            'locale/*/*/*.mo',
+            'locale/*/*/*.po',
         ]
     },
     zip_safe=False,
-    requires=[
-        "Django (>=2.2)",
+    requires = [
+        'Django (>=2.2)',
     ],
 )


### PR DESCRIPTION
This reverts commit c3a23e051ab83abaef32a06d8cba22e7de0bcb2b. Previous django-flatblocks releases are tagged with names that are incompatible with this utility. This causes the package to fail to install.