### PR TITLE
Update versions in testing matrix.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,11 @@ jobs:
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9']
         django-version: ['2.2', '3.0', '3.1', 'dev']
+        exclude:
+          - django-version: 'dev'
+            python-version: '3.6'
+          - django-version: 'dev'
+            python-version: '3.7'
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Update testing matrix to exclude Python<3.8 from Django's development version.