### PR TITLE
Update release information for version 1.0.0.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -213,10 +213,12 @@ the `django-better-chunks`_ fork (``django.contrib.site``- and i18n-support).
 Releases
 --------
 
-Unreleased:
-    * Support for Django 2.2, 3.0 and 3.1.
-    * Support for Python 3.6, 3.7, 3.8 and 3.9.
-    * Moved CI to GitHub Actions: https://github.com/jazzband/django-flatblocks/actions
+1.0.0:
+    * Add support for Django 2.2, 3.0, and 3.1.
+    * Add support for Python 3.6, 3.7, 3.8 and 3.9.
+    * Remove support for Django 1.7, 1.8, 1.9, 1.10, and 1.11.
+    * Remove support for Python 3.4 and 3.5.
+    * Move CI to GitHub Actions: https://github.com/jazzband/django-flatblocks/actions
 
 0.9.4:
     * Drop Python 3.3 support.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-flatblocks',
-    version='0.9.4',
+    version='1.0.0',
     description='django-flatblocks acts like django.contrib.flatpages but '
                 'for parts of a page; like an editable help box you want '
                 'show alongside the main content.',
@@ -16,12 +16,13 @@ setup(
     author_email='curtis@tinbrain.net',
     url='http://github.com/funkybob/django-flatblocks/',
     classifiers=[
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
         'Environment :: Plugins',
         'Environment :: Web Environment',
         'Framework :: Django',
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
+        'Framework :: Django :: 3.1',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
@@ -31,6 +32,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Internet :: WWW/HTTP',


### PR DESCRIPTION
  - Add information about Django and Python versions that are no longer supported.
  - Update classifiers.
  - Bump version number.